### PR TITLE
Fix GLFW3 callback AccessViolationException

### DIFF
--- a/Pencil.Gaming/Glfw/Glfw3DelegateTypes.cs
+++ b/Pencil.Gaming/Glfw/Glfw3DelegateTypes.cs
@@ -26,20 +26,35 @@ using System;
 using System.Runtime.InteropServices;
 
 namespace Pencil.Gaming {
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 	public delegate void GlfwErrorFun(GlfwError code,[MarshalAs(UnmanagedType.LPStr)] string desc);
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 	public delegate void GlfwMonitorFun(GlfwMonitorPtr mtor,ConnectionState @enum);
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 	public delegate void GlfwWindowCloseFun(GlfwWindowPtr wnd);
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 	public delegate void GlfwWindowPosFun(GlfwWindowPtr wnd,int x,int y);
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 	public delegate void GlfwWindowRefreshFun(GlfwWindowPtr wnd);
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 	public delegate void GlfwWindowSizeFun(GlfwWindowPtr wnd,int width,int height);
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 	public delegate void GlfwWindowFocusFun(GlfwWindowPtr wnd,bool focus);
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 	public delegate void GlfwKeyFun(GlfwWindowPtr wnd,Key key,int scanCode,KeyAction action,KeyModifiers mods);
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 	public delegate void GlfwCharFun(GlfwWindowPtr wnd,char ch);
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 	public delegate void GlfwMouseButtonFun(GlfwWindowPtr wnd,MouseButton btn,KeyAction action);
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 	public delegate void GlfwWindowIconifyFun(GlfwWindowPtr wnd,bool iconify);
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 	public delegate void GlfwCursorPosFun(GlfwWindowPtr wnd,double x,double y);
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 	public delegate void GlfwCursorEnterFun(GlfwWindowPtr wnd,bool enter);
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 	public delegate void GlfwScrollFun(GlfwWindowPtr wnd,double xoffset,double yoffset);
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 	public delegate void GlfwFramebufferSizeFun(GlfwWindowPtr wnd,int width,int height);
 }
 


### PR DESCRIPTION
Addresses [https://github.com/andykorth/Pencil.Gaming/issues/19](https://github.com/andykorth/Pencil.Gaming/issues/19) by adding `UnmanagedFunctionPointer` attribute to delegates.

Fix described [here](http://stackoverflow.com/a/18182462/382780).

I have only tested this on Win7-64.
