### PR TITLE
Update GLUtils.cs

### DIFF
--- a/Pencil.Gaming/Graphics/GLUtils.cs
+++ b/Pencil.Gaming/Graphics/GLUtils.cs
@@ -601,7 +601,7 @@ namespace Pencil.Gaming.Graphics {
 
 			private static void ParseVElement(string line, List<Vector4> vertices) {
 				string verticesString = line.Substring(2);
-				string[] elements = verticesString.Split(' ');
+				string[] elements = verticesString.Split(null);
 				switch (elements.Length) {
 				case 3:
 					vertices.Add(new Vector4(
@@ -624,7 +624,7 @@ namespace Pencil.Gaming.Graphics {
 				Vector3 result = Vector3.Zero;
 
 				string elementsString = line.Substring(3);
-				string[] elements = elementsString.Split(' ');
+				string[] elements = elementsString.Split(null);
 				if (elements.Length != 3) {
 					throw new AssetLoadException("model", "normals must define 3 elements @ line " + currentLine.ToString());
 				}
@@ -639,7 +639,7 @@ namespace Pencil.Gaming.Graphics {
 				Vector2 result = Vector2.Zero;
 
 				string elementsString = line.Substring(3);
-				string[] elements = elementsString.Split(' ');
+				string[] elements = elementsString.Split(null);
 				if (elements.Length == 3) {
 					Console.WriteLine("WARNING: Object file specifies third texture coordinate, ignored @ line " + currentLine.ToString());
 				} else if (elements.Length != 2) {
@@ -653,7 +653,7 @@ namespace Pencil.Gaming.Graphics {
 				Face result = new Face();
 
 				string elementsString = line.Substring(2);
-				List<string> elements = new List<string>(elementsString.Split(' '));
+				List<string> elements = new List<string>(elementsString.Split(null));
 				elements.RemoveAll(str => string.IsNullOrEmpty(str));
 				List<VertexIndices> vIndices = new List<VertexIndices>(elements.Count);
 				switch (elements.Count) {

--- a/Pencil.Gaming/Graphics/GLUtils.cs
+++ b/Pencil.Gaming/Graphics/GLUtils.cs
@@ -601,7 +601,7 @@ namespace Pencil.Gaming.Graphics {
 
 			private static void ParseVElement(string line, List<Vector4> vertices) {
 				string verticesString = line.Substring(2);
-				string[] elements = verticesString.Split(null);
+				string[] elements = verticesString.Split(null, StringSplitOptions.RemoveEmptyEntries);
 				switch (elements.Length) {
 				case 3:
 					vertices.Add(new Vector4(
@@ -624,7 +624,7 @@ namespace Pencil.Gaming.Graphics {
 				Vector3 result = Vector3.Zero;
 
 				string elementsString = line.Substring(3);
-				string[] elements = elementsString.Split(null);
+				string[] elements = elementsString.Split(null, StringSplitOptions.RemoveEmptyEntries);
 				if (elements.Length != 3) {
 					throw new AssetLoadException("model", "normals must define 3 elements @ line " + currentLine.ToString());
 				}
@@ -639,7 +639,7 @@ namespace Pencil.Gaming.Graphics {
 				Vector2 result = Vector2.Zero;
 
 				string elementsString = line.Substring(3);
-				string[] elements = elementsString.Split(null);
+				string[] elements = elementsString.Split(null, StringSplitOptions.RemoveEmptyEntries);
 				if (elements.Length == 3) {
 					Console.WriteLine("WARNING: Object file specifies third texture coordinate, ignored @ line " + currentLine.ToString());
 				} else if (elements.Length != 2) {
@@ -653,7 +653,7 @@ namespace Pencil.Gaming.Graphics {
 				Face result = new Face();
 
 				string elementsString = line.Substring(2);
-				List<string> elements = new List<string>(elementsString.Split(null));
+				List<string> elements = new List<string>(elementsString.Split(null, StringSplitOptions.RemoveEmptyEntries));
 				elements.RemoveAll(str => string.IsNullOrEmpty(str));
 				List<VertexIndices> vIndices = new List<VertexIndices>(elements.Count);
 				switch (elements.Count) {


### PR DESCRIPTION
Made the .obj file parsing slightly more robust by allowing arbitrary whitespace between elements rather than only single spaces. Since the file has already been split into lines, there's no worry about line separators.

Note that without this change, having multiple spaces between elements generates the confusing message "X can only have 3 or 4 elements", even though it DOES have that many numbers.